### PR TITLE
Add patches and support for 64-bit ARM (aarch64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+_This repository is being updated to move to Swift 4.1, check out the 3.1.1 branch for the previous release._
+
 # Building Swift on ARM
 
 A few, very simple, bash scripts to clone, configure and build Swift on ARM devices. 
@@ -61,3 +63,12 @@ I recommend to perform all these operations in a permanent background `tmux` or 
 Additional steps could be required in some cases (on a RaspberryPi 1 or for Raspbian) [check the latest ARM posts on my blog for additional info](https://www.uraimo.com/category/raspberry/).
 
 To build a different release than the one currently configured in the script, open `checkoutRelease.sh` and `build.sh` and modify the variables on top, with the branch name for the release and the release name for the tgz respectively.
+
+## Previous Releases
+
+You can compile old releases checking out the specific tag:
+
+* [Swift 3.1.0](https://github.com/uraimo/buildSwiftOnARM/tree/3.1.1)
+* [Swift 3.1](https://github.com/uraimo/buildSwiftOnARM/tree/3.1)
+* [Swift 3.0.2](https://github.com/uraimo/buildSwiftOnARM/tree/3.0.2)
+

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,8 @@ INSTALL_DIR=`pwd`/install
 PACKAGE=`pwd`/swift-${REL}.tgz
 #Determine architecture
 case `uname -m` in
+    aarch64)
+	ARCH=aarch64;;
     armv6*)
         ARCH=armv6;;
     *)
@@ -15,6 +17,8 @@ rm -rf $INSTALL_DIR $PACKAGE
 
 
 ./swift/utils/build-script --build-subdir buildbot_linux -R --lldb --llbuild --xctest --swiftpm --foundation --libdispatch -- --install-libdispatch --install-foundation --install-swift --install-lldb --install-llbuild --install-xctest --install-swiftpm --install-prefix=/usr '--swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;dev' --build-swift-static-stdlib --build-swift-static-sdk-overlay --install-destdir=${INSTALL_DIR} --installable-package=${PACKAGE}
+
+if ["x$ARCHx" != "xaarch64x"]; then
 
 echo "+ Fixing up the install package for ARM"
 cp -R swift-corelibs-libdispatch/dispatch/ ${INSTALL_DIR}/usr/lib/swift
@@ -32,3 +36,4 @@ cp swift-corelibs-libdispatch/os/object.h ${INSTALL_DIR}/usr/lib/swift/os
 echo "+ Retar installation package"
 tar -C ${INSTALL_DIR} -czf ${PACKAGE} .
 
+fi # !aarch64

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ rm -rf $INSTALL_DIR $PACKAGE
 
 ./swift/utils/build-script --build-subdir buildbot_linux -R --lldb --llbuild --xctest --swiftpm --foundation --libdispatch -- --install-libdispatch --install-foundation --install-swift --install-lldb --install-llbuild --install-xctest --install-swiftpm --install-prefix=/usr '--swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;dev' --build-swift-static-stdlib --build-swift-static-sdk-overlay --install-destdir=${INSTALL_DIR} --installable-package=${PACKAGE}
 
-if ["x$ARCHx" != "xaarch64x"]; then
+if [ "x${ARCH}x" != "xaarch64x" ]; then
 
 echo "+ Fixing up the install package for ARM"
 cp -R swift-corelibs-libdispatch/dispatch/ ${INSTALL_DIR}/usr/lib/swift

--- a/swift.diffs/PR15174-aarch64_varargs.diff
+++ b/swift.diffs/PR15174-aarch64_varargs.diff
@@ -1,0 +1,235 @@
+diff --git a/lib/ClangImporter/ImportDecl.cpp b/lib/ClangImporter/ImportDecl.cpp
+index 46e499b..a086aea 100644
+--- a/lib/ClangImporter/ImportDecl.cpp
++++ b/lib/ClangImporter/ImportDecl.cpp
+@@ -273,8 +273,13 @@ getSwiftStdlibType(const clang::TypedefNameDecl *D,
+     break;
+ 
+   case MappedCTypeKind::VaList:
+-    if (ClangTypeSize != ClangCtx.getTypeSize(ClangCtx.VoidPtrTy))
+-      return std::make_pair(Type(), "");
++
++    if (ClangTypeSize != ClangCtx.getTypeSize(ClangCtx.VoidPtrTy)) {
++      if (ClangCtx.getTargetInfo().getBuiltinVaListKind() !=
++          clang::TargetInfo::AArch64ABIBuiltinVaList)
++        return std::make_pair(Type(), "");
++    }
++
+     break;
+ 
+   case MappedCTypeKind::ObjCBool:
+diff --git a/stdlib/public/core/CTypes.swift b/stdlib/public/core/CTypes.swift
+index b38de34..2614c44 100644
+--- a/stdlib/public/core/CTypes.swift
++++ b/stdlib/public/core/CTypes.swift
+@@ -204,6 +204,28 @@ extension UInt {
+   }
+ }
+ 
++#if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
++@_fixed_layout
++public struct CVaListPointer {
++  @_versioned // FIXME(sil-serialize-all)
++  internal var value: (__stack: UnsafeMutablePointer<Int>?,
++                       __gr_top: UnsafeMutablePointer<Int>?,
++                       __vr_top: UnsafeMutablePointer<Int>?,
++                       __gr_off: Int32,
++                       __vr_off: Int32)
++
++  @_inlineable // FIXME(sil-serialize-all)
++  public // @testable
++  init(__stack: UnsafeMutablePointer<Int>?,
++       __gr_top: UnsafeMutablePointer<Int>?,
++       __vr_top: UnsafeMutablePointer<Int>?,
++       __gr_off: Int32,
++       __vr_off: Int32) {
++    value = (__stack, __gr_top, __vr_top, __gr_off, __vr_off)
++  }
++}
++
++#else
+ /// A wrapper around a C `va_list` pointer.
+ @_fixed_layout
+ public struct CVaListPointer {
+@@ -224,6 +246,7 @@ extension CVaListPointer : CustomDebugStringConvertible {
+     return value.debugDescription
+   }
+ }
++#endif
+ 
+ @_versioned
+ @_inlineable
+diff --git a/stdlib/public/core/VarArgs.swift b/stdlib/public/core/VarArgs.swift
+index 52e9f21..2758b15 100644
+--- a/stdlib/public/core/VarArgs.swift
++++ b/stdlib/public/core/VarArgs.swift
+@@ -85,6 +85,30 @@ internal let _registerSaveWords = _countGPRegisters + _countSSERegisters * _sseR
+ internal let _countGPRegisters = 16
+ @_versioned
+ internal let _registerSaveWords = _countGPRegisters
++
++#elseif arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
++
++// ARM Procedure Call Standard for aarch64. (IHI0055B)
++// The va_list type may refer to any parameter in a parameter list may be in one
++// of three memory locations depending on its type and position in the argument 
++// list :
++// 1. GP register save area x0 - x7
++// 2. 128-bit FP/SIMD register save area q0 - q7
++// 3. Stack argument area
++
++@_versioned
++internal let _countGPRegisters = 8
++
++@_versioned
++internal let _countFPRegisters = 8
++
++@_versioned
++internal let _fpRegisterWords = 16 /  MemoryLayout<Int>.size
++
++@_versioned
++internal let _registerSaveWords = 
++  _countGPRegisters + (_countFPRegisters * _fpRegisterWords)
++
+ #endif
+ 
+ #if arch(s390x)
+@@ -467,6 +491,138 @@ final internal class _VaListBuilder {
+   internal var storage: ContiguousArray<Int>
+ }
+ 
++#elseif arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
++
++@_fixed_layout // FIXME(sil-serialize-all)
++@_versioned // FIXME(sil-serialize-all)
++final internal class _VaListBuilder {
++  @_inlineable // FIXME(sil-serialize-all)
++  @_versioned // FIXME(sil-serialize-all)
++  internal init() {
++    // Prepare the register save area.
++    allocated = _registerSaveWords
++    storage = allocStorage(wordCount: allocated)
++    // Append stack arguments after register save area.
++    count = allocated
++  }
++
++  @_inlineable // FIXME(sil-serialize-all)
++  @_versioned // FIXME(sil-serialize-all)
++  deinit {
++    if let allocatedStorage = storage {
++      deallocStorage(wordCount: allocated, storage: allocatedStorage)
++    }
++  }
++
++  @_inlineable // FIXME(sil-serialize-all)
++  @_versioned // FIXME(sil-serialize-all)
++  internal func append(_ arg: CVarArg) {
++    var encoded = arg._cVarArgEncoding
++
++    if arg is _CVarArgPassedAsDouble
++      && fpRegistersUsed < _countFPRegisters {
++      var startIndex = (fpRegistersUsed * _fpRegisterWords)
++      for w in encoded {
++        storage[startIndex] = w
++        startIndex += 1
++      }
++      fpRegistersUsed += 1
++    } else if encoded.count == 1
++      && !(arg is _CVarArgPassedAsDouble)
++      && gpRegistersUsed < _countGPRegisters {
++      var startIndex = ( _fpRegisterWords * _countFPRegisters) + gpRegistersUsed
++      storage[startIndex] = encoded[0]
++      gpRegistersUsed += 1
++    } else {
++      // Arguments in stack slot.
++      appendWords(encoded)
++    }
++  }
++
++  @_inlineable // FIXME(sil-serialize-all)
++  @_versioned // FIXME(sil-serialize-all)
++  internal func va_list() -> CVaListPointer {
++    let vr_top = storage + (_fpRegisterWords * _countFPRegisters)
++    let gr_top = vr_top + _countGPRegisters
++
++    return CVaListPointer(__stack: gr_top, __gr_top: gr_top,
++                          __vr_top: vr_top, __gr_off: -64, __vr_off: -128)
++  }
++
++  @_inlineable // FIXME(sil-serialize-all)
++  @_versioned // FIXME(sil-serialize-all)
++  internal func appendWords(_ words: [Int]) {
++    let newCount = count + words.count
++    if newCount > allocated {
++      let oldAllocated = allocated
++      let oldStorage = storage
++      let oldCount = count
++
++      allocated = max(newCount, allocated * 2)
++      let newStorage = allocStorage(wordCount: allocated)
++      storage = newStorage
++      // Count is updated below.
++
++      if let allocatedOldStorage = oldStorage {
++        newStorage.moveInitialize(from: allocatedOldStorage, count: oldCount)
++        deallocStorage(wordCount: oldAllocated, storage: allocatedOldStorage)
++      }
++    }
++
++    let allocatedStorage = storage!
++    for word in words {
++      allocatedStorage[count] = word
++      count += 1
++    }
++  }
++
++  @_inlineable // FIXME(sil-serialize-all)
++  @_versioned // FIXME(sil-serialize-all)
++  internal func rawSizeAndAlignment(
++    _ wordCount: Int
++  ) -> (Builtin.Word, Builtin.Word) {
++    return ((wordCount * MemoryLayout<Int>.stride)._builtinWordValue,
++      requiredAlignmentInBytes._builtinWordValue)
++  }
++
++  @_inlineable // FIXME(sil-serialize-all)
++  @_versioned // FIXME(sil-serialize-all)
++  internal func allocStorage(wordCount: Int) -> UnsafeMutablePointer<Int> {
++    let (rawSize, rawAlignment) = rawSizeAndAlignment(wordCount)
++    let rawStorage = Builtin.allocRaw(rawSize, rawAlignment)
++    return UnsafeMutablePointer<Int>(rawStorage)
++  }
++
++  @_versioned // FIXME(sil-serialize-all)
++  internal func deallocStorage(
++    wordCount: Int, storage: UnsafeMutablePointer<Int>
++  ) {
++    let (rawSize, rawAlignment) = rawSizeAndAlignment(wordCount)
++    Builtin.deallocRaw(storage._rawValue, rawSize, rawAlignment)
++  }
++
++  @_versioned // FIXME(sil-serialize-all)
++  internal let requiredAlignmentInBytes = MemoryLayout<Double>.alignment
++
++  @_versioned // FIXME(sil-serialize-all)
++  internal var count = 0
++
++  @_versioned // FIXME(sil-serialize-all)
++  internal var allocated = 0
++
++  @_versioned // FIXME(sil-serialize-all)
++  internal var storage: UnsafeMutablePointer<Int>!
++
++  @_versioned // FIXME(sil-serialize-all)
++  internal var gpRegistersUsed = 0
++
++  @_versioned // FIXME(sil-serialize-all)
++  internal var fpRegistersUsed = 0
++
++  @_versioned // FIXME(sil-serialize-all)
++  internal var overflowWordsUsed = 0
++}
++
+ #else
+ 
+ /// An object that can manage the lifetime of storage backing a

--- a/swiftpm.diffs/aarch64_triple.diff
+++ b/swiftpm.diffs/aarch64_triple.diff
@@ -1,0 +1,34 @@
+diff --git a/Sources/Build/Triple.swift b/Sources/Build/Triple.swift
+index 1ce1556..c0cc760 100644
+--- a/Sources/Build/Triple.swift
++++ b/Sources/Build/Triple.swift
+@@ -33,6 +33,7 @@ public struct Triple {
+     public enum Arch: String {
+         case x86_64
+         case armv7
++	case aarch64
+         case s390x
+     }
+ 
+@@ -109,6 +110,8 @@ public struct Triple {
+ 
+   #if os(macOS)
+     public static let hostTriple: Triple = .macOS
++  #elseif os(Linux) && arch(arm64)
++    public static let hostTriple: Triple = try! Triple("aarch64-unknown-linux")
+   #elseif os(Linux) && arch(s390x)
+     public static let hostTriple: Triple = try! Triple("s390x-unknown-linux")
+   #else
+diff --git a/Utilities/bootstrap b/Utilities/bootstrap
+index 784a232..f5a245c 100755
+--- a/Utilities/bootstrap
++++ b/Utilities/bootstrap
+@@ -891,6 +891,8 @@ def main():
+     # Compute the build paths.
+     if platform.system() == 'Darwin':
+         build_target = "x86_64-apple-macosx10.10"
++    elif platform.system() == 'Linux' and platform.processor() == 'aarch64':
++        build_target = "aarch64-unknown-linux"
+     elif platform.processor() == 's390x':
+         build_target = "s390x-unknown-linux"
+     else:


### PR DESCRIPTION
Add two patches needed to build Swift 4.1 on aarch64:

1. Add support for VarArgs from [Swift PR 15174](https://github.com/apple/swift/pull/15174)
2. Add triples for aarch64 to swiftpm (no PR yet but similar to [swift-package-manager PR 1546](https://github.com/apple/swift-package-manager/pull/1546))

Note: The existing patches for ARM32 aren't needed for ARM64 but don't appear to hurt anything.

Also disables the extra fixups to the install tarball in build.sh since these don't appear to be necessary on aarch64 (all the changes they try to make are already present in the generated tarball).
